### PR TITLE
Add anchor for Feature list

### DIFF
--- a/frontend/templates/pages/docs.hbs
+++ b/frontend/templates/pages/docs.hbs
@@ -8,7 +8,7 @@
     {{> partials/header activeClass="docs"}}
     <main role="main" id="main" class="docs home">
       {{{docs}}}
-      <h2>Features detected by Modernizr</h2>
+      <h2 id="features">Features detected by Modernizr</h2>
       <table>
         <thead>
             <tr>


### PR DESCRIPTION
I was linking to the docs from a downstream project, the `#features-css` anchor went away when this sweet new site got rolled out. Small change to restore ability to link directly to feature detect docs.